### PR TITLE
Increase --tone-colour options 

### DIFF
--- a/build/docs/static/styles/tui-doc.css
+++ b/build/docs/static/styles/tui-doc.css
@@ -7,7 +7,7 @@
     --main-color: #00ace6;
     --main-accent-color: #4dd2ff;
     --light-text-color: #ebf8ff;
-    --light-text-accent-color: #adbdc5;
+    --light-text-accent-color: #e2e2e2;
     --light-text-highlight-color: #fff;
     --dark-text-color: #161b1d;
     --dark-text-accent-color: #5a6d72;

--- a/build/docs/static/styles/tui-doc.css
+++ b/build/docs/static/styles/tui-doc.css
@@ -2,7 +2,10 @@
     --bg-color: #0b0e0f;
     --bg-accent-color: #161b1d;
     --bg-highlight-color: #4d5f66;
-    --tone-color: #007399;
+    /*darker*/
+    /* --tone-color: #6666ff;  */
+    /* lighter */
+    --tone-color: #8888ff; 
     --tone-acent-color: #0099cc;
     --main-color: #00ace6;
     --main-accent-color: #4dd2ff;


### PR DESCRIPTION
--tone-color: #6666ff; is a darker shade of blue.
--tone-color: #8888ff; is a lighter shade of blue. I recommend this option, but both works, I have tested it and compared results side-by-side.